### PR TITLE
fix: ignore GITHUB_API_URL

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -70,6 +70,7 @@ jobs:
         - 'https://example.com' # failing example
     uses: ./.github/workflows/test-kubelogin.yaml
     with:
+      kubelogin-version: 'latest'
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -73,4 +73,5 @@ jobs:
       kubelogin-version: 'latest'
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
+      skip-cache: 'true'
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -60,3 +60,16 @@ jobs:
       skip-cache: ${{ matrix.skip-cache }}
       with-github-token: 'true'
     secrets: inherit
+
+  test-github-api-override:
+    strategy:
+      matrix:
+        github-api-base-url:
+        - ''
+        - 'https://api.github.com'
+        - 'https://example.com' # failing example
+    uses: ./.github/workflows/test-kubelogin.yaml
+    with:
+      github-api-base-url: ${{ matrix.github-api-base-url }}
+      with-github-token: 'true'
+    secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -62,19 +62,16 @@ jobs:
     secrets: inherit
 
   test-github-api-override:
-    # there are expected test failrues to show the github-api-base-url usage,
-    # it's fine to ignore the error for such cases.
     strategy:
       matrix:
         github-api-base-url:
         - ''
         - 'https://api.github.com'
-        - 'https://example.com' # failing example
+        # - 'https://example.com' # failing example
     uses: ./.github/workflows/test-kubelogin.yaml
     with:
       kubelogin-version: 'latest'
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
       skip-cache: true
-      continue-on-error: true
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -62,16 +62,19 @@ jobs:
     secrets: inherit
 
   test-github-api-override:
+    # there are expected test failrues to show the github-api-base-url usage,
+    # it's fine to ignore the error for such cases.
     strategy:
       matrix:
         github-api-base-url:
         - ''
         - 'https://api.github.com'
-        # - 'https://example.com' # failing example
+        - 'https://example.com' # failing example
     uses: ./.github/workflows/test-kubelogin.yaml
     with:
       kubelogin-version: 'latest'
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
       skip-cache: true
+      continue-on-error: true
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -73,5 +73,5 @@ jobs:
       kubelogin-version: 'latest'
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
-      skip-cache: 'true'
+      skip-cache: true
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -64,7 +64,6 @@ jobs:
   test-github-api-override:
     # there are expected test failrues to show the github-api-base-url usage,
     # it's fine to ignore the error for such cases.
-    continue-on-error: true
     strategy:
       matrix:
         github-api-base-url:
@@ -77,4 +76,5 @@ jobs:
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
       skip-cache: true
+      continue-on-error: true
     secrets: inherit

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -62,6 +62,9 @@ jobs:
     secrets: inherit
 
   test-github-api-override:
+    # there are expected test failrues to show the github-api-base-url usage,
+    # it's fine to ignore the error for such cases.
+    continue-on-error: true
     strategy:
       matrix:
         github-api-base-url:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -62,13 +62,23 @@ jobs:
     secrets: inherit
 
   test-github-api-override:
-    # there are expected test failrues to show the github-api-base-url usage,
-    # it's fine to ignore the error for such cases.
     strategy:
       matrix:
         github-api-base-url:
         - ''
         - 'https://api.github.com'
+    uses: ./.github/workflows/test-kubelogin.yaml
+    with:
+      kubelogin-version: 'latest'
+      github-api-base-url: ${{ matrix.github-api-base-url }}
+      with-github-token: 'true'
+      skip-cache: true
+    secrets: inherit
+
+  test-github-api-override-bad-case:
+    strategy:
+      matrix:
+        github-api-base-url:
         - 'https://example.com' # failing example
     uses: ./.github/workflows/test-kubelogin.yaml
     with:
@@ -76,5 +86,7 @@ jobs:
       github-api-base-url: ${{ matrix.github-api-base-url }}
       with-github-token: 'true'
       skip-cache: true
+      # there are expected test failrues to show the github-api-base-url usage,
+      # it's fine to ignore the error for such cases.
       continue-on-error: true
     secrets: inherit

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -19,6 +19,10 @@ on:
       github-api-base-url:
         description: 'github api base url override to use'
         required: false
+      continue-on-error:
+        description: 'continue for error?'
+        required: false
+        default: false
   # for integration testing
   workflow_call:
     inputs:
@@ -41,6 +45,11 @@ on:
         type: string
         description: 'github api base url override to use'
         required: false
+      continue-on-error:
+        type: string
+        description: 'continue for error?'
+        required: false
+        default: false
 
 jobs:
   test-with-github-token:
@@ -62,6 +71,7 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
+      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin
@@ -83,6 +93,7 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
+      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -16,6 +16,9 @@ on:
         description: 'with github token?'
         required: false
         default: 'true'
+      github-api-base-url:
+        description: 'github api base url override to use'
+        required: false
   # for integration testing
   workflow_call:
     inputs:
@@ -34,6 +37,10 @@ on:
         description: 'with github token?'
         required: false
         default: 'true'
+      github-api-base-url:
+        type: string
+        description: 'github api base url override to use'
+        required: false
 
 jobs:
   test-with-github-token:
@@ -54,6 +61,7 @@ jobs:
       with:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
+        github-api-base-url: ${{ inputs.github-api-base-url }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin
@@ -74,6 +82,7 @@ jobs:
       with:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
+        github-api-base-url: ${{ inputs.github-api-base-url }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -97,4 +97,4 @@ jobs:
     - run: |
         kubelogin --version
       name: Invoke kubelogin
-      continue-on-error: ${{ inputs.continue-on-error }}
+      if: ${{ success() }}

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -82,6 +82,7 @@ jobs:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ inputs.continue-on-error }}
     if: ${{ inputs.with-github-token != 'true' }}
 
     steps:
@@ -93,7 +94,6 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
-      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -19,6 +19,10 @@ on:
       github-api-base-url:
         description: 'github api base url override to use'
         required: false
+      continue-on-error:
+        description: 'continue for error?''
+        required: false
+        default: false
   # for integration testing
   workflow_call:
     inputs:
@@ -41,6 +45,11 @@ on:
         type: string
         description: 'github api base url override to use'
         required: false
+      continue-on-error:
+        type: string
+        description: 'continue for error?''
+        required: false
+        default: false
 
 jobs:
   test-with-github-token:
@@ -48,6 +57,7 @@ jobs:
       matrix:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
+    continue-on-error: ${{ inputs.continue-on-error }}
     runs-on: ${{ matrix.os }}
     if: ${{ inputs.with-github-token == 'true' }}
 
@@ -71,6 +81,7 @@ jobs:
       matrix:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
+    continue-on-error: ${{ inputs.continue-on-error }}
     runs-on: ${{ matrix.os }}
     if: ${{ inputs.with-github-token != 'true' }}
 

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -46,7 +46,7 @@ on:
         description: 'github api base url override to use'
         required: false
       continue-on-error:
-        type: string
+        type: boolean
         description: 'continue for error?'
         required: false
         default: false

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -20,7 +20,7 @@ on:
         description: 'github api base url override to use'
         required: false
       continue-on-error:
-        description: 'continue for error?''
+        description: 'continue for error?'
         required: false
         default: false
   # for integration testing

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
-    continue-on-error: ${{ inputs.continue-on-error }}
     runs-on: ${{ matrix.os }}
     if: ${{ inputs.with-github-token == 'true' }}
 
@@ -72,6 +71,7 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
+      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin
@@ -81,7 +81,6 @@ jobs:
       matrix:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
-    continue-on-error: ${{ inputs.continue-on-error }}
     runs-on: ${{ matrix.os }}
     if: ${{ inputs.with-github-token != 'true' }}
 
@@ -94,6 +93,7 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
+      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -75,6 +75,7 @@ jobs:
     - run: |
         kubelogin --version
       name: Invoke kubelogin
+      continue-on-error: ${{ inputs.continue-on-error }}
 
   test-without-github-token:
     strategy:
@@ -97,4 +98,4 @@ jobs:
     - run: |
         kubelogin --version
       name: Invoke kubelogin
-      if: ${{ success() }}
+      continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -82,7 +82,6 @@ jobs:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ inputs.continue-on-error }}
     if: ${{ inputs.with-github-token != 'true' }}
 
     steps:
@@ -94,6 +93,8 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
+      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin
+      continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -47,7 +47,7 @@ on:
         required: false
       continue-on-error:
         type: string
-        description: 'continue for error?''
+        description: 'continue for error?'
         required: false
         default: false
 

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -19,10 +19,6 @@ on:
       github-api-base-url:
         description: 'github api base url override to use'
         required: false
-      continue-on-error:
-        description: 'continue for error?'
-        required: false
-        default: false
   # for integration testing
   workflow_call:
     inputs:
@@ -45,11 +41,6 @@ on:
         type: string
         description: 'github api base url override to use'
         required: false
-      continue-on-error:
-        type: string
-        description: 'continue for error?'
-        required: false
-        default: false
 
 jobs:
   test-with-github-token:
@@ -71,7 +62,6 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
-      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin
@@ -93,7 +83,6 @@ jobs:
         kubelogin-version: ${{ inputs.kubelogin-version }}
         skip-cache: ${{ inputs.skip-cache }}
         github-api-base-url: ${{ inputs.github-api-base-url }}
-      continue-on-error: ${{ inputs.continue-on-error }}
     - run: |
         kubelogin --version
       name: Invoke kubelogin

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Skip cache check? When set to "true", the action will always download the latest version of kubelogin.'
     required: false
     default: 'false'
+  github-api-base-url:
+    description: 'The base URL of GitHub API. Defaults to https://api.github.com.'
+    required: false
 branding:
   color: green
 runs:

--- a/lib/index.js
+++ b/lib/index.js
@@ -14797,7 +14797,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.releaseArtifactURL = exports.resolveLatestVersion = exports.isLatestVersion = void 0;
+exports.createOctoKitClient = exports.releaseArtifactURL = exports.resolveLatestVersion = exports.isLatestVersion = void 0;
 const action_1 = __nccwpck_require__(1231);
 const KUBELOGIN_REPO_OWNER = 'Azure';
 const KUBELOGIN_REPO = 'kubelogin';
@@ -14806,12 +14806,9 @@ function isLatestVersion(version) {
     return v === 'latest' || v === '*' || v === '';
 }
 exports.isLatestVersion = isLatestVersion;
-function resolveLatestVersion() {
+function resolveLatestVersion(opts) {
     return __awaiter(this, void 0, void 0, function* () {
-        if (!process.env.GITHUB_TOKEN) {
-            throw new Error('GITHUB_TOKEN is not set, unable to resolve the latest version of kubelogin');
-        }
-        const octokit = new action_1.Octokit();
+        const octokit = createOctoKitClient(opts);
         const { data } = yield octokit.repos.getLatestRelease({
             owner: KUBELOGIN_REPO_OWNER,
             repo: KUBELOGIN_REPO,
@@ -14824,6 +14821,17 @@ function releaseArtifactURL(paths) {
     return `https://github.com/${KUBELOGIN_REPO_OWNER}/${KUBELOGIN_REPO}/releases/download/${paths.join('/')}`;
 }
 exports.releaseArtifactURL = releaseArtifactURL;
+const DEFAULT_OCTOKIT_CLIENT_OPTIONS = {
+    // We should use api.github.com for fetching the canonical release versions.
+    baseUrl: 'https://api.github.com',
+};
+function createOctoKitClient(opts) {
+    if (!process.env.GITHUB_TOKEN) {
+        throw new Error('GITHUB_TOKEN is not set, unable to resolve the latest version of kubelogin');
+    }
+    return new action_1.Octokit(Object.assign(Object.assign({}, DEFAULT_OCTOKIT_CLIENT_OPTIONS), (opts !== null && opts !== void 0 ? opts : {})));
+}
+exports.createOctoKitClient = createOctoKitClient;
 
 
 /***/ }),
@@ -14961,12 +14969,12 @@ function resolvePlatform() {
 }
 // getReleaseArtifact retrieves a release artifact with specified version and platform.
 // platform is resolved automatically if not specified.
-function getReleaseArtifact(version, platform) {
+function getReleaseArtifact(version, opts) {
     return __awaiter(this, void 0, void 0, function* () {
         if ((0, gh_1.isLatestVersion)(version)) {
-            version = yield (0, gh_1.resolveLatestVersion)();
+            version = yield (0, gh_1.resolveLatestVersion)(opts === null || opts === void 0 ? void 0 : opts.octokitClientOptions);
         }
-        platform = platform || resolvePlatform();
+        const platform = (opts === null || opts === void 0 ? void 0 : opts.platform) || resolvePlatform();
         const artifactName = `kubelogin-${platform}.zip`;
         return {
             version,
@@ -15098,12 +15106,19 @@ const core = __importStar(__nccwpck_require__(2186));
 const release_1 = __nccwpck_require__(7776);
 const inputNameKubeloginVersion = 'kubelogin-version';
 const inputNameSkipCache = 'skip-cache';
+const inputNameGitHubAPIBaseUrl = 'github-api-base-url';
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const kubeloginVersion = core.getInput(inputNameKubeloginVersion);
         const skipCache = core.getInput(inputNameSkipCache) === 'true';
         core.debug(`kubelogin-version: ${kubeloginVersion} skip-cache: ${skipCache}`);
-        const artifact = yield (0, release_1.getReleaseArtifact)(kubeloginVersion);
+        const githubAPIBaseUrl = core.getInput(inputNameGitHubAPIBaseUrl);
+        const opts = {};
+        if (githubAPIBaseUrl) {
+            opts.octokitClientOptions = { baseUrl: githubAPIBaseUrl };
+            core.info(`github-api-base-url: ${githubAPIBaseUrl}`);
+        }
+        const artifact = yield (0, release_1.getReleaseArtifact)(kubeloginVersion, opts);
         core.debug(`Resolved artifact: ${JSON.stringify(artifact)}`);
         yield (0, release_1.setupArtifact)(artifact, skipCache);
     });

--- a/src/gh.test.ts
+++ b/src/gh.test.ts
@@ -1,4 +1,8 @@
-import { isLatestVersion } from './gh';
+import { isLatestVersion, createOctoKitClient } from './gh';
+
+beforeAll(() => {
+  process.env['GITHUB_ACTION'] = 'github-action-test-env';
+});
 
 test('isLatestVersion', () => {
   ['latest', 'LATEST', '', '*'].forEach((v) => {
@@ -8,4 +12,21 @@ test('isLatestVersion', () => {
   ['v0.0.24'].forEach((v) => {
     expect(isLatestVersion(v)).toBe(false);
   });
+});
+
+// issue #3
+test('createOctoKitClient - non-empty GITHUB_API_URL', () => {
+  // even if GITHUB_API_URL is set, it should be ignored
+  process.env['GITHUB_API_URL'] = 'https://foobar.com';
+  const client = createOctoKitClient();
+  expect(client.request.endpoint.DEFAULTS.baseUrl).toBe(
+    'https://api.github.com'
+  );
+});
+
+test('createOctoKitClient - with baseUrl override', () => {
+  const client = createOctoKitClient({
+    baseUrl: 'https://foobar.com',
+  });
+  expect(client.request.endpoint.DEFAULTS.baseUrl).toBe('https://foobar.com');
 });

--- a/src/gh.test.ts
+++ b/src/gh.test.ts
@@ -2,6 +2,7 @@ import { isLatestVersion, createOctoKitClient } from './gh';
 
 beforeAll(() => {
   process.env['GITHUB_ACTION'] = 'github-action-test-env';
+  process.env['GITHUB_TOKEN'] = 'github-action-test-token';
 });
 
 test('isLatestVersion', () => {

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -8,14 +8,10 @@ export function isLatestVersion(version: string): boolean {
   return v === 'latest' || v === '*' || v === '';
 }
 
-export async function resolveLatestVersion(): Promise<string> {
-  if (!process.env.GITHUB_TOKEN) {
-    throw new Error(
-      'GITHUB_TOKEN is not set, unable to resolve the latest version of kubelogin'
-    );
-  }
-
-  const octokit = new Octokit();
+export async function resolveLatestVersion(
+  opts?: OctokitClientOptions
+): Promise<string> {
+  const octokit = createOctoKitClient(opts);
   const { data } = await octokit.repos.getLatestRelease({
     owner: KUBELOGIN_REPO_OWNER,
     repo: KUBELOGIN_REPO,
@@ -27,4 +23,26 @@ export function releaseArtifactURL(paths: string[]): string {
   return `https://github.com/${KUBELOGIN_REPO_OWNER}/${KUBELOGIN_REPO}/releases/download/${paths.join(
     '/'
   )}`;
+}
+
+export type OctokitClientOptions = {
+  baseUrl?: string;
+};
+
+const DEFAULT_OCTOKIT_CLIENT_OPTIONS: OctokitClientOptions = {
+  // We should use api.github.com for fetching the canonical release versions.
+  baseUrl: 'https://api.github.com',
+};
+
+export function createOctoKitClient(opts?: OctokitClientOptions) {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error(
+      'GITHUB_TOKEN is not set, unable to resolve the latest version of kubelogin'
+    );
+  }
+
+  return new Octokit({
+    ...DEFAULT_OCTOKIT_CLIENT_OPTIONS,
+    ...(opts ?? {}),
+  });
 }

--- a/src/release.ts
+++ b/src/release.ts
@@ -3,6 +3,7 @@ import * as tc from '@actions/tool-cache';
 import * as fs from 'fs';
 import path from 'path';
 import {
+  OctokitClientOptions,
   isLatestVersion,
   releaseArtifactURL,
   resolveLatestVersion,
@@ -49,17 +50,22 @@ export interface KubeloginArtifact {
   readonly checksumUrl: string;
 }
 
+export type GetReleaseArtifactOpts = {
+  platform?: Platform;
+  octokitClientOptions?: OctokitClientOptions;
+};
+
 // getReleaseArtifact retrieves a release artifact with specified version and platform.
 // platform is resolved automatically if not specified.
 export async function getReleaseArtifact(
   version: string,
-  platform?: Platform
+  opts?: GetReleaseArtifactOpts
 ): Promise<KubeloginArtifact> {
   if (isLatestVersion(version)) {
-    version = await resolveLatestVersion();
+    version = await resolveLatestVersion(opts?.octokitClientOptions);
   }
 
-  platform = platform || resolvePlatform();
+  const platform = opts?.platform || resolvePlatform();
 
   const artifactName = `kubelogin-${platform}.zip`;
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,15 +1,27 @@
 import * as core from '@actions/core';
-import { getReleaseArtifact, setupArtifact } from './release';
+import {
+  GetReleaseArtifactOpts,
+  getReleaseArtifact,
+  setupArtifact,
+} from './release';
 
 const inputNameKubeloginVersion = 'kubelogin-version';
 const inputNameSkipCache = 'skip-cache';
+const inputNameGitHubAPIBaseUrl = 'github-api-base-url';
 
 async function main() {
   const kubeloginVersion = core.getInput(inputNameKubeloginVersion);
   const skipCache = core.getInput(inputNameSkipCache) === 'true';
   core.debug(`kubelogin-version: ${kubeloginVersion} skip-cache: ${skipCache}`);
 
-  const artifact = await getReleaseArtifact(kubeloginVersion);
+  const githubAPIBaseUrl = core.getInput(inputNameGitHubAPIBaseUrl);
+  const opts: GetReleaseArtifactOpts = {};
+  if (githubAPIBaseUrl) {
+    opts.octokitClientOptions = { baseUrl: githubAPIBaseUrl };
+    core.debug(`github-api-base-url: ${githubAPIBaseUrl}`);
+  }
+
+  const artifact = await getReleaseArtifact(kubeloginVersion, opts);
   core.debug(`Resolved artifact: ${JSON.stringify(artifact)}`);
 
   await setupArtifact(artifact, skipCache);

--- a/src/run.ts
+++ b/src/run.ts
@@ -18,7 +18,7 @@ async function main() {
   const opts: GetReleaseArtifactOpts = {};
   if (githubAPIBaseUrl) {
     opts.octokitClientOptions = { baseUrl: githubAPIBaseUrl };
-    core.debug(`github-api-base-url: ${githubAPIBaseUrl}`);
+    core.info(`github-api-base-url: ${githubAPIBaseUrl}`);
   }
 
   const artifact = await getReleaseArtifact(kubeloginVersion, opts);


### PR DESCRIPTION
octokit/action.js by default resolve the api base url via `GITHUB_API_URL`:

https://github.com/octokit/action.js/blob/86bfb4edd3ac588b69fb46ee73a48c8bfd60ef7b/src/index.ts#L54-L57

When running the action in GHEC environment, it will unable to discover the latest version from github.com .

This pull request fixed by ignoring this environment variable by default. If an environment is required to use API endpoint other than `api.github.com`, user can override via input `github-api-base-url`.

Resolve #3 