### PR TITLE
feat: lockdown github actions versions and permissions

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,6 +28,8 @@ jobs:
       skip-cache: ${{ matrix.skip-cache }}
       with-github-token: 'true'
     secrets: inherit
+    permissions:
+      contents: read
 
   test-specified-versions-no-github-token:
     strategy:
@@ -44,6 +46,8 @@ jobs:
       skip-cache: ${{ matrix.skip-cache }}
       with-github-token: 'false'
     secrets: inherit
+    permissions:
+      contents: read
 
   test-specified-versions-with-github-token:
     strategy:
@@ -90,3 +94,5 @@ jobs:
       # it's fine to ignore the error for such cases.
       continue-on-error: true
     secrets: inherit
+    permissions:
+      contents: read

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -90,7 +90,7 @@ jobs:
 
     if: ${{ inputs.with-github-token != 'true' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       name: Checkout code
     - uses: ./ # use current branch
       name: Setup kubelogin

--- a/.github/workflows/test-kubelogin.yaml
+++ b/.github/workflows/test-kubelogin.yaml
@@ -58,8 +58,10 @@ jobs:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    if: ${{ inputs.with-github-token == 'true' }}
+    permissions:
+      contents: read
 
+    if: ${{ inputs.with-github-token == 'true' }}
     steps:
     - uses: actions/checkout@v3
       name: Checkout code
@@ -83,8 +85,10 @@ jobs:
         # TODO(hbc): add ARM64 runners
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    if: ${{ inputs.with-github-token != 'true' }}
+    permissions:
+      contents: read
 
+    if: ${{ inputs.with-github-token != 'true' }}
     steps:
     - uses: actions/checkout@v3
       name: Checkout code

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -13,8 +13,8 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: 16
     - run: npm ci

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
This pull request lockdown the actions versions to commit and specified permissions in job level.

Verified in my fork repo:

- test build: https://github.com/bcho/use-kubelogin/pull/1
- unit test:

<img width="395" alt="image" src="https://github.com/Azure/use-kubelogin/assets/1975118/625c0aa3-9dc9-441a-800c-200bc92af725">


- integration test:

<img width="639" alt="image" src="https://github.com/Azure/use-kubelogin/assets/1975118/9c21f736-6e51-4dd9-87ad-298c81141462">
